### PR TITLE
Add structured JSON logging with console and file output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 ### Django ###
 *.log
+logs/
 *.pot
 *.pyc
 __pycache__/

--- a/pynigeriaBackend/log_formatters.py
+++ b/pynigeriaBackend/log_formatters.py
@@ -1,0 +1,24 @@
+import json
+import logging
+from datetime import datetime, timezone
+
+
+class JsonFormatter(logging.Formatter):
+    """Custom JSON formatter for structured logging."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_data = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "module": record.name,
+            "line": record.lineno,
+        }
+
+        if record.exc_info:
+            log_data["exception"] = self.formatException(record.exc_info)
+
+        if hasattr(record, "extra_fields"):
+            log_data.update(record.extra_fields)
+
+        return json.dumps(log_data)

--- a/pynigeriaBackend/settings.py
+++ b/pynigeriaBackend/settings.py
@@ -223,3 +223,44 @@ AUTHENTICATION_BACKENDS = (
 
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.getenv("SOCIAL_AUTH_GOOGLE_OAUTH2_KEY")
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.getenv("SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET")
+
+# Logging
+LOG_DIR = BASE_DIR / "logs"
+LOG_DIR.mkdir(exist_ok=True)
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "json": {
+            "()": "pynigeriaBackend.log_formatters.JsonFormatter",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "rich.logging.RichHandler",
+            "rich_tracebacks": True,
+            "show_time": True,
+            "show_path": False,
+            "markup": True,
+        },
+        "file": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "json",
+            "filename": str(LOG_DIR / "app.log"),
+            "maxBytes": 10485760,  # 10 MB
+            "backupCount": 5,
+        },
+    },
+    "loggers": {
+        "authentication": {"handlers": ["console", "file"], "level": "INFO", "propagate": False},
+        "job_listing_api": {"handlers": ["console", "file"], "level": "INFO", "propagate": False},
+        "knowledge_base_api": {"handlers": ["console", "file"], "level": "INFO", "propagate": False},
+        "django.request": {"handlers": ["console", "file"], "level": "INFO", "propagate": False},
+        "django.security": {"handlers": ["console", "file"], "level": "INFO", "propagate": False},
+    },
+    "root": {
+        "handlers": ["console", "file"],
+        "level": "INFO",
+    },
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "python-dotenv>=1.2.2",
     "qrcode>=8.2",
     "requests>=2.32.5",
+    "rich>=14.3.3",
     "uvicorn>=0.41.0",
     "whitenoise>=6.12.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -486,6 +486,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -618,6 +639,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -673,6 +703,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "qrcode" },
     { name = "requests" },
+    { name = "rich" },
     { name = "uvicorn" },
     { name = "whitenoise" },
 ]
@@ -698,6 +729,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "qrcode", specifier = ">=8.2" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "rich", specifier = ">=14.3.3" },
     { name = "uvicorn", specifier = ">=0.41.0" },
     { name = "whitenoise", specifier = ">=6.12.0" },
 ]
@@ -841,6 +873,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview

This PR introduces a structured logging system across the project. Previously there was no logging configuration — errors, auth events, and runtime behaviour were invisible unless you happened to be watching the terminal. This sets up a solid foundation that contributors can build on.

---

## What Changed

### `pynigeriaBackend/log_formatters.py` *(new file)*

A custom `JsonFormatter` class that serialises every log record to a JSON object. Each entry includes:

| Field | Description |
|---|---|
| `timestamp` | ISO 8601 UTC |
| `level` | `INFO`, `WARNING`, `ERROR`, etc. |
| `message` | The log message |
| `module` | The logger name (e.g. `authentication.views`) |
| `line` | Line number in source |
| `exception` | Full traceback if one is attached |
| `extra_fields` | Any extra context passed by the caller |

---

### `pynigeriaBackend/settings.py`

Added a `LOGGING` configuration block at the bottom of settings with two handlers:

| Handler | Output | Format |
|---|---|---|
| `console` | Terminal | Rich (coloured, human-readable) |
| `file` | `logs/app.log` | JSON (structured, machine-readable) |

The file handler is a `RotatingFileHandler` — it caps at 10 MB and keeps 5 backups (`app.log.1` through `app.log.5`) before discarding old logs.

Named loggers configured at `INFO`:

| Logger | Covers |
|---|---|
| `authentication` | Registration, login, 2FA, social auth |
| `job_listing_api` | Job and bookmark events |
| `knowledge_base_api` | Upload and approval events |
| `django.request` | Unhandled request errors |
| `django.security` | CSRF, auth violations |

`root` is also set to `INFO` as a catch-all for third-party libraries and anything without a named logger. All named loggers have `propagate: False` to prevent duplicate entries.

---

### `.gitignore`

Added `logs/` so the log folder and its rotating files are never committed.

---

### New dependency — `rich`

Required for the `RichHandler` console output.
```bash
uv add rich
# or
uv sync  # if pulling from uv.lock after merge
```

---

## How to Use

### Basic usage

At the top of any view, serializer, or utility file:
```python
import logging

logger = logging.getLogger(__name__)
```

`__name__` resolves to the module path (e.g. `authentication.views`), which routes it to the correct named logger automatically.

### Log levels
```python
logger.debug("Detailed info for debugging")     # not shown at INFO level
logger.info("User registered: %s", user.email)
logger.warning("Unexpected state: %s", detail)
logger.error("Something failed: %s", error)
logger.exception("Unhandled error")             # like error but auto-attaches traceback
```

> **Tip:** Prefer `logger.info("msg %s", value)` over `logger.info(f"msg {value}")` — the `%s` form skips string formatting entirely if the log level is suppressed.

### Attaching extra context

Pass structured fields alongside the message using `extra_fields`:
```python
logger.info(
    "Login success",
    extra={"extra_fields": {"user": user.email, "provider": user.auth_provider}},
)
```

This gets merged into the JSON output:
```json
{
  "timestamp": "2026-03-13T10:45:00+00:00",
  "level": "INFO",
  "message": "Login success",
  "module": "authentication.views",
  "line": 102,
  "user": "test@example.com",
  "provider": "google"
}
```

### Exceptions

Use `logger.exception()` inside an `except` block — it automatically captures and formats the full traceback into the `exception` field:
```python
try:
    send_verification_email(user)
except Exception:
    logger.exception("Failed to send verification email to %s", user.email)
```

---

## Contributor Guidance — Log Levels

All loggers are set to `INFO` by default. If a specific app becomes too noisy or needs stricter monitoring, the level can be raised in `settings.py`:
```python
# Raise job_listing_api to only capture warnings and above
"job_listing_api": {"handlers": ["console", "file"], "level": "WARNING", "propagate": False},
```

Use `DEBUG` freely in development — it produces no output at the default `INFO` level and has zero cost when suppressed.